### PR TITLE
ci: :construction_worker: add workflows for doc generation and version update

### DIFF
--- a/.github/workflows/run-gen-doc-when-dispatch.yml
+++ b/.github/workflows/run-gen-doc-when-dispatch.yml
@@ -1,0 +1,61 @@
+name: Run Plugin
+
+on:
+  repository_dispatch:
+    types: [run-plugin]
+
+jobs:
+  use-artifact:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Example Repository
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Build and Install Plugin
+        run: mvn -DskipTests=true install
+
+
+      - name: Set Artifact URL
+        run: |
+          ARTIFACT_ID="${{ github.event.client_payload.artifact_id }}"
+          if [ -z "$ARTIFACT_ID" ]; then
+            echo "Error: ARTIFACT_ID is not set."
+            exit 1
+          fi
+          ARTIFACT_URL="https://api.github.com/repos/TongchengOpenSource/smart-doc/actions/artifacts/${ARTIFACT_ID}/zip"
+          echo "artifact_url=$ARTIFACT_URL" >> $GITHUB_ENV
+
+      - name: Download Artifact
+        run: |
+          echo "Downloading artifact from ${{ env.artifact_url }}"
+          curl -L -o smart-doc-maven-jar.zip -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ env.artifact_url }}"
+
+      - name: Create Directory and Move File
+        run: |
+          mkdir -p ~/.m2/repository/com/ly/smart-doc
+          mv smart-doc-maven-jar.zip ~/.m2/repository/com/ly/smart-doc/
+          echo "Listing files in target directory:"
+          ls -lh ~/.m2/repository/com/ly/smart-doc
+
+      - name: Unzip Artifact
+        run: |
+          unzip -o -d ~/.m2/repository/com/ly/smart-doc ~/.m2/repository/com/ly/smart-doc/smart-doc-maven-jar.zip || (echo "Unzip failed" && exit 1)
+          ls -lh ~/.m2/repository/com/ly/smart-doc
+
+      - name: Build and Install Plugin Again
+        run: mvn -DskipTests=true install
+
+
+      - name: Generate doc
+        run: mvn -DskipTests=true smart-doc:html
+
+

--- a/.github/workflows/update-smart-doc-version.yml
+++ b/.github/workflows/update-smart-doc-version.yml
@@ -1,0 +1,36 @@
+name: Update Plugin Version
+
+on:
+  repository_dispatch:
+    types: [update-plugin-version]
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Example Repository
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Update Smart-Doc Version in pom.xml
+        run: |
+          version=${{ github.event.client_payload.version }}
+          mvn versions:set-property -Dproperty=smart-doc.version -DnewVersion=$version -DgenerateBackupPoms=false
+
+      - name: Commit and Push Changes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --global user.name 'github-actions[bot]'
+          git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add pom.xml
+          git commit -m "chore(pom.xml): :arrow_up: update smart-doc version to ${{ github.event.client_payload.version }}"
+          git push origin master

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>17</java.version>
         <util.version>2.2.2</util.version>
-        <smart-doc.version>3.0.5</smart-doc.version>
+        <smart-doc.version>3.0.6</smart-doc.version>
         <smart-doc.group>com.ly.smart-doc</smart-doc.group>
         <asciidoctor.input.directory>${project.basedir}/src/docs/asciidoc</asciidoctor.input.directory>
         <generated.asciidoc.directory>${project.build.directory}/asciidoc/generated</generated.asciidoc.directory>

--- a/src/test/java/com/power/doc/word/WordTest.java
+++ b/src/test/java/com/power/doc/word/WordTest.java
@@ -72,7 +72,8 @@ public class WordTest {
         builderTemplate.checkAndInit(config, Boolean.TRUE);
         config.setParamsDataToTree(false);
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework(),
+                Thread.currentThread().getContextClassLoader());
         ApiSchema<ApiDoc> apiData = docBuildTemplate.getApiData(configBuilder);
         List<ApiDoc> apiDocList = apiData.getApiDatas();
         System.out.println(apiDocList);
@@ -163,7 +164,8 @@ public class WordTest {
 
     private List<ApiDoc> list(ApiConfig config, JavaProjectBuilder javaProjectBuilder) {
         ProjectDocConfigBuilder configBuilder = new ProjectDocConfigBuilder(config, javaProjectBuilder);
-        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework());
+        IDocBuildTemplate<ApiDoc> docBuildTemplate = BuildTemplateFactory.getDocBuildTemplate(config.getFramework(),
+                Thread.currentThread().getContextClassLoader());
         ApiSchema<ApiDoc> apiData = docBuildTemplate.getApiData(configBuilder);
         List<ApiDoc> apiDocList = apiData.getApiDatas();
         if (config.isAllInOne()) {


### PR DESCRIPTION

- Introduce GitHub Actions to automatically generate API documentation when a Smart Doc PR is opened.
- Add a new workflow to update the Smart Doc plugin version in the Maven repository.
- Refactor the code to use the context class loader for doc building in tests.
- Bump up the Smart Doc version to 3.0.6 in the pom.xml.