### PR TITLE
feat(torna): implement unit tests for TornaApi integration

### DIFF
--- a/src/test/java/com/power/doc/torna/TornaApiTest.java
+++ b/src/test/java/com/power/doc/torna/TornaApiTest.java
@@ -1,0 +1,54 @@
+package com.power.doc.torna;
+
+import com.ly.doc.builder.TornaBuilder;
+import com.ly.doc.builder.rpc.RpcTornaBuilder;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.torna.TornaApi;
+import com.power.doc.utils.ApiConfigUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.Assert;
+
+import java.io.IOException;
+
+/**
+ * TornaApi Test
+ *
+ * @author linwumingshi
+ */
+@DisplayName("TornaApiTest")
+public class TornaApiTest {
+
+    private ApiConfig apiConfig;
+
+
+    @BeforeEach
+    public void init() throws IOException {
+        apiConfig = ApiConfigUtils.getProjectApiConfig();
+        Assert.notNull(apiConfig, "ApiConfig is null");
+    }
+
+    /**
+     * Rest Api convert to TornaApi
+     */
+    @DisplayName("Rest Api convert to TornaApi")
+    @Test
+    public void pushRestApi() {
+        TornaApi tornaApi = TornaBuilder.getTornaApi(apiConfig);
+        Assert.notNull(tornaApi, "TornaApi is null");
+        Assert.notEmpty(tornaApi.getApis(), "TornaApi Apis is empty");
+    }
+
+
+    /**
+     * Dubbo Api convert to TornaApi
+     */
+    @DisplayName("Dubbo Api convert to TornaApi")
+    @Test
+    public void pushRPCApi() {
+        TornaApi tornaApi = RpcTornaBuilder.getTornaApi(apiConfig);
+        Assert.notNull(tornaApi, "TornaApi is null");
+        Assert.notEmpty(tornaApi.getApis(), "TornaApi Apis is empty");
+    }
+}

--- a/src/test/java/com/power/doc/utils/ApiConfigUtils.java
+++ b/src/test/java/com/power/doc/utils/ApiConfigUtils.java
@@ -1,0 +1,68 @@
+package com.power.doc.utils;
+
+import com.google.gson.Gson;
+import com.ly.doc.model.ApiConfig;
+import com.ly.doc.model.ApiDataDictionary;
+import com.ly.doc.model.ApiErrorCodeDictionary;
+import com.power.common.util.CollectionUtil;
+import lombok.experimental.UtilityClass;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * ApiConfigUtils
+ *
+ * @author linwumingshi
+ */
+@UtilityClass
+public class ApiConfigUtils {
+
+
+    /**
+     * Get Demo ApiConfig
+     *
+     * @return ApiConfig
+     * @throws IOException IOException
+     */
+    public static ApiConfig getProjectApiConfig() throws IOException {
+        // Read JSON from file
+        try (Reader reader = new BufferedReader(new InputStreamReader(
+                Objects.requireNonNull(ApiConfigUtils.class.getClassLoader().getResourceAsStream("smart-doc.json"))))) {
+
+            // get gson
+            Gson gson = new Gson();
+
+            // convert JSON to ApiConfig
+            ApiConfig apiConfig = gson.fromJson(reader, ApiConfig.class);
+            if (Objects.isNull(apiConfig)) {
+                return null;
+            }
+
+            // set baseDir and codePath
+            apiConfig.setBaseDir(System.getProperty("user.dir"));
+            apiConfig.setCodePath("src/main/java");
+
+            List<ApiErrorCodeDictionary> errorCodeDictionaries = apiConfig.getErrorCodeDictionaries();
+            if (CollectionUtil.isNotEmpty(errorCodeDictionaries)) {
+                for (ApiErrorCodeDictionary errorCodeDictionary : errorCodeDictionaries) {
+                    errorCodeDictionary.setEnumClass(Class.forName(errorCodeDictionary.getEnumClassName()));
+                }
+            }
+            List<ApiDataDictionary> dataDictionaries = apiConfig.getDataDictionaries();
+            if (CollectionUtil.isNotEmpty(dataDictionaries)) {
+                for (ApiDataDictionary dataDictionary : dataDictionaries) {
+                    dataDictionary.setEnumClass(Class.forName(dataDictionary.getEnumClassName()));
+                }
+            }
+            return apiConfig;
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}


### PR DESCRIPTION
- Add TornaApiTest class to run unit tests on TornaApi functionality.
- Include tests for both REST and RPC API conversions to Torna entities.
- Introduce ApiConfigUtils to handle ApiConfig loading from a JSON file.

After PR  https://github.com/TongchengOpenSource/smart-doc/pull/903 Merge