### PR TITLE
refactor: replace main with `@Test` annotations for `JUnit 5` compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,12 +22,21 @@
         <generated.asciidoc.directory>${project.build.directory}/asciidoc/generated</generated.asciidoc.directory>
         <asciidoctor.html.output.directory>${project.build.directory}/asciidoc/html</asciidoctor.html.output.directory>
         <asciidoctor.pdf.output.directory>${project.build.directory}/asciidoc/pdf</asciidoctor.pdf.output.directory>
+        <spring.cloud.version>2023.0.3</spring.cloud.version>
         <spring.boot.version>3.3.3</spring.boot.version>
     </properties>
 
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>${spring.cloud.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -72,7 +81,6 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
-            <version>4.1.0</version>
         </dependency>
 
         <dependency>
@@ -210,6 +218,15 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>${smart-doc.group}</groupId>
@@ -220,9 +237,9 @@
                         <!--格式为：groupId:artifactId;参考如下-->
                         <!--也可以支持正则式如：com.alibaba:.* -->
                         <include>com.power.doc:.*</include>
-<!--                        <include>com.baomidou:mybatis-plus-extension</include>-->
+                        <!--                        <include>com.baomidou:mybatis-plus-extension</include>-->
                         <include>com.github.shalousun:.*</include>
-<!--                        <include>org.springframework:spring-web</include>-->
+                        <!--                        <include>org.springframework:spring-web</include>-->
                     </includes>
                     <!--指定生成文档的使用的配置文件-->
                     <configFile>./src/main/resources/smart-doc.json</configFile>

--- a/src/test/java/com/power/doc/lamda/ListTest.java
+++ b/src/test/java/com/power/doc/lamda/ListTest.java
@@ -1,21 +1,24 @@
 package com.power.doc.lamda;
 
 
+import org.junit.jupiter.api.Test;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class ListTest {
 
-    public static void main(String[] args) {
+
+    @Test
+    public void test() {
         List<Integer> numbers = new ArrayList<>();
         numbers.add(1);
         numbers.add(3);
         numbers.add(5);
         numbers.add(6);
         numbers.stream().filter(number -> number < 5);
-        for (Integer i:numbers){
+        for (Integer i : numbers) {
             System.out.println(i);
         }
-
     }
 }

--- a/src/test/java/com/power/doc/reflect/GetMethodGenericType.java
+++ b/src/test/java/com/power/doc/reflect/GetMethodGenericType.java
@@ -1,12 +1,14 @@
 package com.power.doc.reflect;
 
+import org.junit.jupiter.api.Test;
+
 import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 
 public class GetMethodGenericType {
 
-    public static void main(String[] args) {
+    @Test
+    public void test() {
         try {
             Class c = Class.forName("org.springframework.data.domain.Slice");
             Method m = c.getDeclaredMethod("getContent");

--- a/src/test/java/com/power/doc/reflect/ReflectionConstantsValue.java
+++ b/src/test/java/com/power/doc/reflect/ReflectionConstantsValue.java
@@ -1,18 +1,22 @@
 package com.power.doc.reflect;
 
 import com.power.doc.constants.ApiConstants;
+import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
 
 public class ReflectionConstantsValue {
-    public static void main(String[] args) {
+
+
+    @Test
+    public void test() {
         try {
             // 获取Test类的Class对象
             Class<?> clazz = ApiConstants.class;
 
             Field[] fields = clazz.getDeclaredFields();
-            for(Field f:fields) {
-                System.out.println("修饰："+f.getModifiers());
+            for (Field f : fields) {
+                System.out.println("修饰：" + f.getModifiers());
                 // 获取字段的值
                 Object constantValue = f.get(null);
                 // 输出结果

--- a/src/test/java/com/power/doc/utils/CmdUtil.java
+++ b/src/test/java/com/power/doc/utils/CmdUtil.java
@@ -1,10 +1,13 @@
 package com.power.doc.utils;
 
-import java.net.Socket;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.Assert;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
+import java.net.Socket;
 
 /**
  * @author yu3.sun on 2022/4/13
@@ -12,26 +15,27 @@ import java.io.PrintWriter;
 public class CmdUtil {
 
 
-
-  public static String executeCmd(String cmd, String zkServer, String zkPort) throws IOException {
-    StringBuilder sb;
-    try (Socket s = new Socket(zkServer, Integer.parseInt(zkPort));
-        PrintWriter out = new PrintWriter(s.getOutputStream(), true);
-        BufferedReader reader = new BufferedReader(new InputStreamReader(s.getInputStream()))) {
-      out.println(cmd);
-      String line = reader.readLine();
-      sb = new StringBuilder();
-      while (line != null) {
-        sb.append(line);
-        sb.append("\n");
-        line = reader.readLine();
-      }
+    public static String executeCmd(String cmd, String zkServer, String zkPort) throws IOException {
+        StringBuilder sb;
+        try (Socket s = new Socket(zkServer, Integer.parseInt(zkPort));
+             PrintWriter out = new PrintWriter(s.getOutputStream(), true);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(s.getInputStream()))) {
+            out.println(cmd);
+            String line = reader.readLine();
+            sb = new StringBuilder();
+            while (line != null) {
+                sb.append(line);
+                sb.append("\n");
+                line = reader.readLine();
+            }
+        }
+        return sb.toString();
     }
-    return sb.toString();
-  }
 
-  public static void main(String[] args) throws IOException {
-    String me = executeCmd("stat","localhost","16701");
-    System.out.println(me);
-  }
+
+    @Test
+    public void testCmd() throws IOException {
+        String me = executeCmd("stat", "localhost", "16701");
+        Assert.notNull(me, "me is null");
+    }
 }

--- a/src/test/java/com/power/doc/utils/ConvertString.java
+++ b/src/test/java/com/power/doc/utils/ConvertString.java
@@ -1,11 +1,12 @@
 package com.power.doc.utils;
 
-import java.util.StringTokenizer;
+import org.junit.jupiter.api.Test;
 
 public class ConvertString {
 
 
-    public static void main(String[] args) {
+    @Test
+    public void test() {
         String str = "java.lang.List";
         // 正则表达式匹配包名
         String regex = "\\b\\w+\\.(?=\\w+\\b)";
@@ -14,6 +15,7 @@ public class ConvertString {
         System.out.println(result);
     }
 
+
     public static String convertString(String str) {
         int first = str.indexOf("<");
         int last = str.lastIndexOf(">");
@@ -21,9 +23,9 @@ public class ConvertString {
             return str;
         } else {
             String start = str.substring(0, first);
-            String end = str.substring(last+1);
-            String middle = str.substring(first+1, last);
-            return start+"<"+processMiddle(middle)+">"+end;
+            String end = str.substring(last + 1);
+            String middle = str.substring(first + 1, last);
+            return start + "<" + processMiddle(middle) + ">" + end;
         }
     }
 
@@ -39,8 +41,7 @@ public class ConvertString {
                 sb.append(convertString(part));
             }
             return sb.toString();
-        }
-        else {
+        } else {
             return removePackage(middle);
         }
     }
@@ -48,9 +49,8 @@ public class ConvertString {
     // 去除包名
     private static String removePackage(String str) {
         if (str.contains(".")) {
-            return str.substring(str.lastIndexOf(".")+1);
-        }
-        else {
+            return str.substring(str.lastIndexOf(".") + 1);
+        } else {
             return str;
         }
     }


### PR DESCRIPTION
- Replace Java main methods with JUnit `@Test` annotations in `LambdaListTest`,`GetMethodGenericType`, `ReflectionConstantsValue`, `CmdUtil`, and `ConvertString`to ensure compatibility with `JUnit 5` testing standards.
- Update dependencies in pom.xml to align with `JUnit 5` and `Spring Boot 3.3.3`.
- Update `Spring-Cloud` Version